### PR TITLE
Add Access-Control-Allow-Origin header

### DIFF
--- a/index.php
+++ b/index.php
@@ -298,6 +298,7 @@ foreach($passlist as $timedpass)
 //ob_clean();
 if(isset($_REQUEST['type']) && $_REQUEST['type'] == "json")
   {
+    header("Access-Control-Allow-Origin: *");
     header("Content-type: application/json; charset=utf-8");
     echo json_encode($jsonarray);
   }


### PR DESCRIPTION
This is needed in case of JSON request (not for JSONP).

It could be needed to restrict the allowed origins (e.g. by replaying the host from which the request is originated) if only specific origins are allowed.